### PR TITLE
UIColor+Extension, structure Colors created

### DIFF
--- a/Expense Tracker.xcodeproj/project.pbxproj
+++ b/Expense Tracker.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		09234BF229ED7A63002A9E9C /* AddExpenseModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09234BF129ED7A63002A9E9C /* AddExpenseModuleBuilder.swift */; };
 		092D92462A0AED2900794A45 /* CoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092D92452A0AED2900794A45 /* CoordinatorProtocol.swift */; };
 		096854A029F7FFF400969D59 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0968549F29F7FFF400969D59 /* LaunchScreen.storyboard */; };
+		098BA6D02A0EBD390007C633 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098BA6CF2A0EBD390007C633 /* UIColor+Extension.swift */; };
 		099471CC29EAC585009F1A2E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099471CB29EAC585009F1A2E /* AppDelegate.swift */; };
 		099471CE29EAC585009F1A2E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099471CD29EAC585009F1A2E /* SceneDelegate.swift */; };
 		099471D529EAC587009F1A2E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 099471D429EAC587009F1A2E /* Assets.xcassets */; };
@@ -19,6 +20,7 @@
 		09B264CD29F5CF1300FC1B2E /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B264CC29F5CF1300FC1B2E /* Strings.swift */; };
 		09B84CB42A0C0DF100EB4B95 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B84CB32A0C0DF100EB4B95 /* Category.swift */; };
 		09B84CB62A0C0EFC00EB4B95 /* AddExpenseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B84CB52A0C0EFC00EB4B95 /* AddExpenseCoordinator.swift */; };
+		09DB34322A10E630001964D5 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DB34312A10E630001964D5 /* Colors.swift */; };
 		09EE90ED2A03CBE80017CC3F /* AddExpenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EE90EC2A03CBE80017CC3F /* AddExpenseView.swift */; };
 		09F49B102A069E8000619F6B /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F49B0F2A069E8000619F6B /* AppCoordinator.swift */; };
 		09F49B122A06A30A00619F6B /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F49B112A06A30A00619F6B /* TabBarController.swift */; };
@@ -31,6 +33,7 @@
 		09234BF129ED7A63002A9E9C /* AddExpenseModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddExpenseModuleBuilder.swift; sourceTree = "<group>"; };
 		092D92452A0AED2900794A45 /* CoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorProtocol.swift; sourceTree = "<group>"; };
 		0968549F29F7FFF400969D59 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		098BA6CF2A0EBD390007C633 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		099471C829EAC585009F1A2E /* Expense Tracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Expense Tracker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		099471CB29EAC585009F1A2E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		099471CD29EAC585009F1A2E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -41,6 +44,7 @@
 		09B264CC29F5CF1300FC1B2E /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		09B84CB32A0C0DF100EB4B95 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		09B84CB52A0C0EFC00EB4B95 /* AddExpenseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddExpenseCoordinator.swift; sourceTree = "<group>"; };
+		09DB34312A10E630001964D5 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		09EE90EC2A03CBE80017CC3F /* AddExpenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddExpenseView.swift; sourceTree = "<group>"; };
 		09F49B0F2A069E8000619F6B /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		09F49B112A06A30A00619F6B /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
@@ -97,6 +101,7 @@
 				097BFAA929F5A31900945B9D /* Core */,
 				09F49B142A06E51600619F6B /* Services */,
 				097BFAAA29F5A33D00945B9D /* Presentation */,
+				098BA6CE2A0EBD0C0007C633 /* Extensions */,
 				09B84CB22A0C0DB900EB4B95 /* Models */,
 			);
 			path = Source;
@@ -105,6 +110,7 @@
 		097BFAA929F5A31900945B9D /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				09DB34302A10E603001964D5 /* Theme */,
 				09234BF329ED7BB0002A9E9C /* App */,
 			);
 			path = Core;
@@ -125,6 +131,14 @@
 				09234BEC29ED6D8E002A9E9C /* AddExpense */,
 			);
 			path = Modules;
+			sourceTree = "<group>";
+		};
+		098BA6CE2A0EBD0C0007C633 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				098BA6CF2A0EBD390007C633 /* UIColor+Extension.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		099471BF29EAC585009F1A2E = {
@@ -171,6 +185,14 @@
 				09B84CB32A0C0DF100EB4B95 /* Category.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		09DB34302A10E603001964D5 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				09DB34312A10E630001964D5 /* Colors.swift */,
+			);
+			path = Theme;
 			sourceTree = "<group>";
 		};
 		09F49B132A06E49E00619F6B /* TabBarController */ = {
@@ -335,6 +357,7 @@
 				09234BEE29ED6DCC002A9E9C /* AddExpenseViewController.swift in Sources */,
 				099471CC29EAC585009F1A2E /* AppDelegate.swift in Sources */,
 				092D92462A0AED2900794A45 /* CoordinatorProtocol.swift in Sources */,
+				09DB34322A10E630001964D5 /* Colors.swift in Sources */,
 				099471CE29EAC585009F1A2E /* SceneDelegate.swift in Sources */,
 				09F49B122A06A30A00619F6B /* TabBarController.swift in Sources */,
 				09B84CB62A0C0EFC00EB4B95 /* AddExpenseCoordinator.swift in Sources */,
@@ -342,6 +365,7 @@
 				09F49B102A069E8000619F6B /* AppCoordinator.swift in Sources */,
 				09EE90ED2A03CBE80017CC3F /* AddExpenseView.swift in Sources */,
 				09B84CB42A0C0DF100EB4B95 /* Category.swift in Sources */,
+				098BA6D02A0EBD390007C633 /* UIColor+Extension.swift in Sources */,
 				09B264CD29F5CF1300FC1B2E /* Strings.swift in Sources */,
 				09234BF229ED7A63002A9E9C /* AddExpenseModuleBuilder.swift in Sources */,
 			);

--- a/Expense Tracker/Source/Core/Theme/Colors.swift
+++ b/Expense Tracker/Source/Core/Theme/Colors.swift
@@ -1,0 +1,14 @@
+//
+//  Colors.swift
+//  Expense Tracker
+//
+//  Created by Ekaterina Volobueva on 14.05.2023.
+//
+
+import UIKit
+
+struct Colors {
+    static let turquoiseColor = UIColor.colorWith(light: UIColor.lightTurquoiseColor, dark: UIColor.darkTurquoiseColor)
+    
+    static let tabBarTextColor = UIColor.colorWith(light: UIColor.lightTurquoiseColor, dark: UIColor.darkTurquoiseColor)
+}

--- a/Expense Tracker/Source/Extensions/UIColor+Extension.swift
+++ b/Expense Tracker/Source/Extensions/UIColor+Extension.swift
@@ -45,6 +45,9 @@ extension UIColor {
             alpha: CGFloat(1.0)
         )
     }
+}
+
+extension UIColor {
     static let lightTurquoiseColor = UIColor.hexStringToUIColor(hex: "#48CAD2")
     static let darkTurquoiseColor = UIColor.hexStringToUIColor(hex: "#3EB8C0")
 }

--- a/Expense Tracker/Source/Extensions/UIColor+Extension.swift
+++ b/Expense Tracker/Source/Extensions/UIColor+Extension.swift
@@ -1,0 +1,52 @@
+//
+//  UIColor+Extension.swift
+//  Expense Tracker
+//
+//  Created by Ekaterina Volobueva on 12.05.2023.
+//
+
+import UIKit
+
+extension UIColor {
+    static func colorWith(light: UIColor, dark: UIColor) -> UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor { (traitCollection: UITraitCollection) -> UIColor in
+                switch traitCollection.userInterfaceStyle {
+                case .dark:
+                    return dark
+                default:
+                    return light
+                }
+            }
+        } else {
+            // Для iOS 12 и ниже просто возвращаем светлый цвет
+            return light
+        }
+    }
+    
+    static func hexStringToUIColor (hex:String) -> UIColor {
+        var cString:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        
+        if (cString.hasPrefix("#")) {
+            cString.remove(at: cString.startIndex)
+        }
+        
+        if ((cString.count) != 6) {
+            return UIColor.gray
+        }
+        
+        var rgbValue:UInt64 = 0
+        Scanner(string: cString).scanHexInt64(&rgbValue)
+        
+        return UIColor(
+            red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
+            alpha: CGFloat(1.0)
+        )
+    }
+    static let lightTurquoiseColor = UIColor.hexStringToUIColor(hex: "#48CAD2")
+    static let darkTurquoiseColor = UIColor.hexStringToUIColor(hex: "#3EB8C0")
+}
+
+

--- a/Expense Tracker/Source/Presentation/Modules/AddExpense/AddExpenseCoordinator/AddExpenseCoordinator.swift
+++ b/Expense Tracker/Source/Presentation/Modules/AddExpense/AddExpenseCoordinator/AddExpenseCoordinator.swift
@@ -20,6 +20,6 @@ final class AddExpenseCoordinator: AddExpenseCoordinatorProtocol {
     }
     
     func pushCategory(with model: Category) {
-    //пока что останется пустой
+        //пока что останется пустой
     }
 }

--- a/Expense Tracker/Source/Presentation/Modules/AddExpense/AddExpenseViewController.swift
+++ b/Expense Tracker/Source/Presentation/Modules/AddExpense/AddExpenseViewController.swift
@@ -38,7 +38,7 @@ final class AddExpenseViewController: UIViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .white
+        view.backgroundColor = UIColor.systemBackground
     }
 }
 

--- a/Expense Tracker/Source/Presentation/TabBarController/TabBarController.swift
+++ b/Expense Tracker/Source/Presentation/TabBarController/TabBarController.swift
@@ -16,6 +16,7 @@ final class TabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTabBarItems()
+        setupTabBarAppearance()
     }
     
     //MARK: - Private func
@@ -36,18 +37,34 @@ final class TabBarController: UITabBarController {
                            addExpenseViewController,
                            settingsViewController]
     }
+    
+    private func setupTabBarAppearance() {
+        UITabBarItem.appearance().setTitleTextAttributes([NSAttributedString.Key.foregroundColor: Colors.turquoiseColor], for: .normal)
+        UITabBarItem.appearance().setTitleTextAttributes([NSAttributedString.Key.foregroundColor: Colors.turquoiseColor], for: .selected)
+        
+        if #available(iOS 13.0, *) {
+            let appearance = UITabBarAppearance()
+            appearance.stackedLayoutAppearance.normal.iconColor = Colors.turquoiseColor
+            appearance.stackedLayoutAppearance.selected.iconColor = Colors.turquoiseColor
+            appearance.stackedLayoutAppearance.normal.titleTextAttributes = [.foregroundColor: Colors.turquoiseColor]
+            appearance.stackedLayoutAppearance.selected.titleTextAttributes = [.foregroundColor: Colors.turquoiseColor]
+            self.tabBar.standardAppearance = appearance
+        } else {
+            self.tabBar.tintColor = Colors.turquoiseColor
+        }
+    }
 }
 
 final class ReportViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = UIColor.systemBackground
     }
 }
 
 final class SettingsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = UIColor.systemBackground
     }
 }


### PR DESCRIPTION
Создана отдельная папку Extension, в ней файл UIColor+Extension, в файле расширен UIColor методом, который будет обрабатывать какой отдавать нужный цвет в зависимости от выбранной темы. (UITraitCollection)

Так как в дизайне используются hex цвета, в расширении добавлена функция, которая преобразует hex код в UIColor.

Также в расширении добавлены статические константы, которые преобразуют hex цвет #48CAD2 в UIColor - это цвет кнопки для светлой темы. И hex цвет #3EB8C0 в UIColor - это цвет кнопки для темной темы.

Создана структура Colors со статическими константами. Эти свойства дергают функцию colorWith, куда передаются 2 цвета, в зависимости от темы.

